### PR TITLE
Improve .gitignore util by appending to .gitignore if file already exists

### DIFF
--- a/utils/gi
+++ b/utils/gi
@@ -8,7 +8,9 @@ elif [[ $1 = list ]]; then
     echo "$result"
 else
     if [[ -f .gitignore ]]; then
-        echo ".gitignore already exists, aborting."
+        result=`echo "$result" | grep -v "# Created by http://www.gitignore.io"`
+        echo ".gitignore already exists, appending"
+        echo "$result" >> .gitignore
     else
         echo "$result" > .gitignore
     fi


### PR DESCRIPTION
Great little util for using [gitignore.io](http://www.gitignore.io).

Just improved it a little by appending new types to existing .gitignore file.
I also remove the duplicate `# Created by http://www.gitignore.io` line when appending.

---

[Gist](https://gist.github.com/matiassingers/8248b4345fb56b8a08da)
