### PR TITLE
Fix name of a Map.lookup argument

### DIFF
--- a/articles/gentle-introduction-monad-transformers.md
+++ b/articles/gentle-introduction-monad-transformers.md
@@ -478,7 +478,7 @@ userLogin :: EitherIO LoginError Text
 userLogin = do
   token      <- getToken
   userpw     <- maybe (liftEither (Left NoSuchUser))
-                  return (Map.lookup token users)
+                  return (Map.lookup domain users)
   password   <- liftIO (T.putStrLn "Enter your password:" >> T.getLine)
 
   if userpw == password


### PR DESCRIPTION
It should be `domain`, not `token` - as it was in the original version of `userLogin` function
